### PR TITLE
Add support for Unleash ContextProvider bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ io:
 - The configuration takes care of creating configuring `UnleashConfig` and creating an instance of `io.getunleash.Unleash`.
 - This takes care of binding all strategy instances (in-built and custom) to the `Unleash` instance.
 
+### Including Spring Security Details in the Unleash Context
+Provide an `UnleashContextProvider` bean to add details that Unleash can leverage when evaluating toggle strategies:
+```java
+@Bean
+@ConditionalOnMissingBean
+public UnleashContextProvider unleashContextProvider(final UnleashProperties unleashProperties) {
+    return () -> {
+        UnleashContext.Builder builder = UnleashContext.builder();
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof User) {
+            builder.userId((((User)principal).getUsername());
+        }
+        
+        return builder
+            .appName(unleashProperties.getAppName())
+            .environment(unleashProperties.getEnvironment())
+            .build();
+    };
+}
+```
+
 ### Usage
 - Create a feature toggle `demo-toggle` on unleash server and enabled it.
 - Create an interface FeatureDemoService and 2 implementation

--- a/springboot-unleash-autoconfigure/src/main/java/org/unleash/features/config/UnleashAutoConfiguration.java
+++ b/springboot-unleash-autoconfigure/src/main/java/org/unleash/features/config/UnleashAutoConfiguration.java
@@ -2,10 +2,13 @@ package org.unleash.features.config;
 
 import io.getunleash.DefaultUnleash;
 import io.getunleash.Unleash;
+import io.getunleash.UnleashContext;
+import io.getunleash.UnleashContextProvider;
 import io.getunleash.repository.OkHttpFeatureFetcher;
 import io.getunleash.strategy.Strategy;
 import io.getunleash.util.UnleashConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -30,9 +33,19 @@ public class UnleashAutoConfiguration {
             UnleashAutoConfiguration::setHttpFetcherInBuilder;
 
     @Bean
-    public Unleash unleash(final UnleashProperties unleashProperties) {
+    @ConditionalOnMissingBean
+    public UnleashContextProvider unleashContextProvider(final UnleashProperties unleashProperties) {
+        return () -> UnleashContext.builder()
+                .appName(unleashProperties.getAppName())
+                .environment(unleashProperties.getEnvironment())
+                .build();
+    }
+
+    @Bean
+    public Unleash unleash(final UnleashProperties unleashProperties, UnleashContextProvider unleashContextProvider) {
         final UnleashConfig unleashConfig = httpFetcherFunc.apply(UnleashConfig
                         .builder()
+                        .unleashContextProvider(unleashContextProvider)
                         .appName(unleashProperties.getAppName())
                         .environment(unleashProperties.getEnvironment())
                         .unleashAPI(unleashProperties.getApiUrl())


### PR DESCRIPTION
I'm not certain how to leverage the `UnleashContextProvider` bean in the threadlocal usage. Also a customizer approach that gives use a builder that has already been created and populated with app and env details is even better. But this is a good first pass.